### PR TITLE
Live tv module added

### DIFF
--- a/controllers/index_controller.js
+++ b/controllers/index_controller.js
@@ -3,7 +3,9 @@ const ModulesDataListGenerator = require('../services/modules_data_list_generato
 module.exports = {
   index: async(req, res) => {
     res.render('index', {
-      modulesDataList: (await ModulesDataListGenerator.perform(req.query.url))
+      modulesDataList: (
+        await ModulesDataListGenerator.perform(req.query.url || process.env.MAIN_WEBSITE_URL)
+      )
     });
   }
 }

--- a/helpers/handlebars.js
+++ b/helpers/handlebars.js
@@ -1,8 +1,45 @@
 module.exports = {
-  module_slug: (v) => require('slug')(v.replace(/\//g, '-')),
+  and: (condition1, condition2) => {
+    return condition1 && condition2;
+  },
+  different: (leftValue, rightValue) => {
+    return leftValue != rightValue;
+  },
+  equals: (leftValue, rightValue) => {
+    return leftValue == rightValue;
+  },
+  firstTransmisionMediastreamId: (transmissions) => {
+    if (transmissions.length == 0)
+      return undefined;
+    return transmissions[0].videos.id;
+  },
+  hasDirectaTransmission: (transmissions) => {
+    for (let transmission of transmissions)
+      if (transmission.directa)
+        return true;
+    return false;
+  },
+  includes: (str, subStr) => {
+    return str.toLowerCase().includes(subStr.toLowerCase());
+  },
+  increment: (val) => {
+    return parseInt(val) + 1;
+  },
   limit: (array, limit) => {
     if (!Array.isArray(array))
       return [];
     return array.slice(0, limit);
+  },
+  moduleSlug: (v) => require('slug')(v.replace(/\//g, '-')),
+  not: (v) => {
+    return !v;
+  },
+  setVar: (varName, varValue, options) => {
+    options.data.root[varName] = varValue;
+  },
+  incompleteString: (str, limit) => {
+    if(str.length <= limit)
+      return str;
+    return str.substring(0, limit) + "...";
   }
 }

--- a/public/javascripts/livetv_mediastream_video_player.js
+++ b/public/javascripts/livetv_mediastream_video_player.js
@@ -1,0 +1,118 @@
+class LivetvMediastreamVideoPlayer extends MediastreamVideoPlayer {
+  constructor(htmlId, basicOptions, livetvModule) {
+    super(htmlId, basicOptions);
+    this.fullscreenStatus = "off"; // on, off
+    this.livetvModule = livetvModule;
+    this.videoId = this.getVideoId();
+    this.init();
+    this.isVideoDoubleClickValidation = false;
+    this.playerVideoUpdated = false;
+  }
+
+  init() {
+    setTimeout(super.init.bind(this), 0);
+    setTimeout(this.initHtmlVariables.bind(this), 0);
+  }
+
+  initHtmlVariables() {
+    this.glideContainer = $('.tv-slider').find('.glide');
+    this.sliderContainerPreview = $('#slider-container-preview-' + this.videoId);
+    this.sliderContainerPlayer = $('#slider-container-player-' + this.videoId);
+  }
+
+  onFullscreenChange() {
+    if(this.fullscreenStatus == "off")
+      this.fullscreenStatus = "on";
+    else
+      this.fullscreenStatus = "off";
+    this.livetvModule.fullscreenEvent = this.fullscreenStatus;
+
+    if(!this.playerVideoUpdated && this.fullscreenStatus == "off")
+      setTimeout(this.showPreview.bind(this), 500);
+  }
+
+  updateVideoPlayer() {
+    this.player.seekTo(-1, undefined);
+    this.playerVideoUpdated = true;
+  }
+
+  onPlay() {
+    if(this.playerVideoUpdated)
+      return;
+    this.isVideoDoubleClickValidation = true;
+    this.updateVideoPlayer();
+    setTimeout(this.stopPlayingOtherVideos.bind(this), 0);
+    setTimeout(() => {
+      this.livetvModule.showAllPreviews().then(this.showPlayer.bind(this))
+    }, 0);
+    setTimeout(this.positionGlide.bind(this), 0);
+  }
+
+  /* Calling the showAllPreviews() function and then the showPlayer() function. */
+  onTimeUpdate() {
+    if(this.isVideoDoubleClickValidation && this.sliderContainerPlayer.hasClass('hidden')) {
+      if(this.livetvModule.mediastreamVideoPlayers[this.videoId])
+        this.livetvModule.mediastreamVideoPlayers[this.videoId].player.videoStop();
+      this.isVideoDoubleClickValidation = false;
+    }
+  }
+  
+  onVideoError() {
+    if(this.livetvModule.mediastreamVideoPlayers[this.videoId] != undefined)
+      this.livetvModule.mediastreamVideoPlayers[this.videoId].player.destroy();
+    delete this.livetvModule.mediastreamVideoPlayers[this.videoId];
+    this.showPreview();
+  }
+
+  onVideoStop() {
+    this.playerVideoUpdated = false;
+    if(this.livetvModule.isFullscreen())
+      return;
+    setTimeout(this.showPreview.bind(this), 500);
+  }
+
+  positionGlide() {
+    var sliderIndex = parseInt(this.sliderContainerPlayer.data('sliderIndex'));
+    if(this.livetvModule.glide.index == sliderIndex)
+      return
+    var movementDirection = this.livetvModule.glide.index < sliderIndex ? '>' : '<';
+
+    const interval = setInterval(() => {
+      this.livetvModule.glide.go(movementDirection);
+      if(this.livetvModule.glide.index == sliderIndex)
+        clearInterval(interval);
+    }, 0);
+  }
+
+  stopPlayingOtherVideos() {
+    let player = undefined;
+    for (var identifier in this.livetvModule.mediastreamVideoPlayers)
+      if(this.videoId != identifier) {
+        player = this.livetvModule.mediastreamVideoPlayers[identifier].player;
+        if(player.isPlaying())
+          player.videoStop();
+      }
+  }
+
+  showPlayer() {
+    if(this.sliderContainerPreview.hasClass('hidden'))
+      return;
+    this.sliderContainerPreview.addClass('hidden');
+    this.sliderContainerPlayer.removeClass('hidden');
+  }
+
+  showPreview() {
+    if(this.sliderContainerPlayer.hasClass('hidden'))
+      return;
+    this.sliderContainerPlayer.addClass('hidden');
+    this.sliderContainerPreview.removeClass('hidden');
+    let playTvButton = this.sliderContainerPreview.find('.play-tv-button');
+    if(playTvButton.hasClass('hidden'))
+      playTvButton.removeClass('hidden');
+  }
+
+  getVideoId() {
+    let data = this.htmlId.split('-');
+    return data[data.length - 1];
+  }
+}

--- a/public/javascripts/livetv_module.js
+++ b/public/javascripts/livetv_module.js
@@ -1,0 +1,188 @@
+class LivetvModule {
+  constructor() {
+    this.fullscreenEvent = undefined;
+    this.lastDateTimeToFullscreen = undefined;
+    this.mediastreamVideoPlayers = {};
+    this.init();
+    this.bindEvents();
+  }
+
+  init() {
+    this.module = $('#livetv-module');
+    this.cancelIfNoContent();
+    this.initHtmlVariables();
+    this.initDynamicDependencies().then(this.saveEmptyGlideSlidesException.bind(this));
+  }
+
+  initDynamicDependencies() {
+    return new Promise((resolve, reject) => {
+      this.initGlide().then(this.defineDimensions.bind(this));
+      resolve();
+    });
+  }
+
+  saveEmptyGlideSlidesException() {
+    var interval = setInterval(() => {
+      this.resetMediastreamPlayers();
+      if(this.glideSlides.css('height') != '0px')
+        clearInterval(interval);
+    }, 800);
+  }
+
+  initHtmlVariables() {
+    this.slider = this.module.find('.tv-slider');
+    this.glideSlides = this.slider.find('.glide__slides');
+    this.sectionImage = this.slider.find('img.section-image');
+    this.sectionEmptyImage = this.slider.find('.section-empty-image');
+    this.sliderContainerPlayer = this.slider.find('.slider-container.player');
+    this.sliderContainerPreviews = $('.slider-container.preview');
+    this.sliderContainerPlayers = $('.slider-container.player');
+  }
+
+  setMediastreamVideoPlayerDimensions() {
+    let sliderContainer = this.module.find('.slider-container');
+    this.mediastreamVideoPlayerWidth = parseInt(sliderContainer.css('width').replace('px', ''));
+    this.mediastreamVideoPlayerHeight = parseInt(sliderContainer.css('height').replace('px', ''));
+  }
+
+  initGlide() {
+    return new Promise((resolve, reject) => {
+      this.glide = new Glide('#livetv-module .main-glide', {
+        draggable: true,
+        type: 'slider',
+        focusAt: 'center',
+        perView: 2,
+        startAt: 0
+      });
+      this.glide.mount();
+      resolve();
+    });
+  }
+
+  defineDimensions() {
+    this.adjustSliderStyles().then(this.setMediastreamVideoPlayerDimensions.bind(this));
+  }
+
+  adjustSliderStyles() {
+    return new Promise((resolve, reject) => {
+      if(this.sectionImage.length) {
+        let sectionImageHeight = this.sectionImage.css('height');
+        let sectionImageWidth = this.sectionImage.css('width');
+
+        this.setDimensions(this.sectionEmptyImage, sectionImageWidth, sectionImageHeight);
+        this.setDimensions(this.sliderContainerPlayer, sectionImageWidth, sectionImageHeight);
+        this.glideSlides.css('height', sectionImageHeight);
+      }
+      resolve();
+    });
+  }
+
+  resetMediastreamPlayers() {
+    this.stopPlayingVideos();
+    this.showAllPreviews().then(this.defineDimensions.bind(this));
+    this.mediastreamVideoPlayers = {};
+  }
+
+  bindEvents() {
+    this.bindWindowResize();
+    this.bindPlayButtons();
+  }
+
+  bindPlayButtons() {
+    var _this = this;
+    this.module.find('.tv-button, .play-tv-button').on('click', function () {
+      var videoId = $(this).data('mdstrmIdentifier');
+      setTimeout(_this.launchMediastreamPlayer.bind(_this, videoId), 0);
+      
+      setTimeout(() => {
+        var playTvButton = _this.slider.find(`#slider-container-preview-${videoId}`)
+          .find('.play-tv-button');
+        playTvButton.addClass('hidden');
+
+        var interval = setInterval(() => {
+          let mediastreamVideoPlayer = _this.mediastreamVideoPlayers[videoId];
+          if(mediastreamVideoPlayer && mediastreamVideoPlayer.player.isPlaying()) {
+            playTvButton.removeClass('hidden');
+            clearInterval(interval);
+          }
+        }, 100);
+      }, 500); 
+    });
+  }
+
+  isVideoFullScreenEvent() {
+    let res = this.fullscreenEvent != undefined;
+    this.fullscreenEvent = undefined;
+    return res;
+  }
+
+  bindWindowResize() {
+    window.addEventListener('resize', () => {
+      setTimeout(() => {
+        if(this.isVideoFullScreenEvent())
+          this.lastDateTimeToFullscreen = new Date().getTime();
+        else if(this.lastDateTimeToFullscreen == undefined ||
+          new Date().getTime() - this.lastDateTimeToFullscreen > 1000)
+          this.resetMediastreamPlayers();
+      }, 500);
+    });
+  }
+
+  launchMediastreamPlayer(videoId) {
+    if(this.mediastreamVideoPlayers[videoId])
+      this.mediastreamVideoPlayers[videoId].player.videoPlay();
+    else {
+      this.mediastreamVideoPlayers[videoId] =
+        new LivetvMediastreamVideoPlayer(`mdstrm-player-${videoId}`, {
+          width: this.mediastreamVideoPlayerWidth,
+          height: this.mediastreamVideoPlayerHeight,
+          type: 'live',
+          id: videoId,
+          autoplay: true
+        },
+      this);
+      this.mediastreamVideoPlayers[videoId].init();
+    }
+  }
+
+  stopPlayingVideos() {
+    let player = undefined;
+    for (let identifier in this.mediastreamVideoPlayers) {
+      player = this.mediastreamVideoPlayers[identifier].player;
+      if(player.isPlaying()) 
+        player.videoStop();
+    }
+  }
+
+  showAllPreviews() {
+    return new Promise((resolve, reject) => {
+      this.sliderContainerPreviews.removeClass('hidden');
+      this.sliderContainerPreviews.find('.play-tv-button').removeClass('hidden');
+      this.sliderContainerPlayers.addClass('hidden');
+      resolve();
+    });
+  }
+
+  setDimensions(element, width, height) {
+    if(!element.length)
+      return;
+    element.css('width', width);
+    element.css('height', height);
+  }
+
+  cancelIfNoContent() {
+    if(this.areAllChannelsDisabled()) {
+      $('#livetv-module').addClass('hidden');
+      return;
+    }
+  }
+
+  areAllChannelsDisabled() {
+    return this.module.find('.tv-buttons-container').find('.tv-button.disabled').length == 5;
+  }
+
+  isFullscreen() {
+    return !!(document.fullscreenElement || document.mozFullScreenElement
+      || document.onwebkitanimationendFullscreenElement || document.msFullscreenElement);
+  }
+}

--- a/public/javascripts/mediastream_video_player.js
+++ b/public/javascripts/mediastream_video_player.js
@@ -1,0 +1,142 @@
+class MediastreamVideoPlayer {
+  constructor(htmlId, basicOptions) {
+    this.htmlId = htmlId;
+    this.basicOptions = basicOptions;
+    this.events = {};
+    this.player = undefined;
+  }
+
+  init() {
+    this.bindEvents();
+    this.initPlayer();
+  }
+
+  bindEvents() {
+    this.events = {
+      onAdsComplete: this.onAdsComplete.bind(this),
+      onAdsFirstQuartile: this.onAdsFirstQuartile.bind(this),
+      onAdsMidpoint: this.onAdsMidpoint.bind(this),
+      onAdsPaused: this.onAdsPaused.bind(this),
+      onAdsResumed: this.onAdsResumed.bind(this),
+      onAdsSkipped: this.onAdsSkipped.bind(this),
+      onAdsStarted: this.onAdsStarted.bind(this),
+      onAdsThirdQuartile: this.onAdsThirdQuartile.bind(this),
+      onAdsUserClose: this.onAdsUserClose.bind(this),
+      onBuffering: this.onBuffering.bind(this),
+      onFullscreenChange: this.onFullscreenChange.bind(this),
+      onPlay: this.onPlay.bind(this),
+      onPlayerReady: this.onPlayerReady.bind(this),
+      onReplay: this.onReplay.bind(this),
+      onSeeked: this.onSeeked.bind(this),
+      onSeeking: this.onSeeking.bind(this),
+      onTimeUpdate: this.onTimeUpdate.bind(this),
+      onVideoEnd: this.onVideoEnd.bind(this),
+      onVideoError: this.onVideoError.bind(this),
+      onVideoStop: this.onVideoStop.bind(this),
+      onVolumeChange: this.onVolumeChange.bind(this),
+    }
+  }
+
+  initPlayer() {
+    this.player = new MediastreamPlayer(this.htmlId, this.getOptions());
+  }
+
+  getOptions() {
+    return { ...this.basicOptions, ...{ events: this.events } };
+  }
+
+  onAdsComplete() {
+  }
+
+  onAdsFirstQuartile() {
+  }
+
+  onAdsMidpoint() {
+  }
+
+  onAdsPaused() {
+  }
+
+  onAdsResumed() {
+  }
+
+  onAdsSkipped() {
+  }
+
+  onAdsStarted() {
+  }
+
+  onAdsThirdQuartile() {
+  }
+
+  onAdsUserClose() {
+  }
+
+  /**
+   * almost always runs after onSeeking (load the data?)
+   */
+  onBuffering() {
+  }
+
+  /**
+   * full screen changes
+   */
+  onFullscreenChange() {
+  }
+
+  /**
+   * when user clicks to play the media content
+   */
+  onPlay() {
+  }
+
+  /**
+   * when the player is ready to interactions (is executed twice)
+   * when the page is loaded or specific part is loaded and that is ready to continue
+   */
+  onPlayerReady() {
+  }
+
+  /**
+   * click on the play to view content again or click on the little button to repeat the content
+   */
+  onReplay() {
+  }
+
+  onSeeked() {
+  }
+
+  /**
+   * search content from source
+   * when user clicks on previous (or next) 10 seconds button or click on the progress bar
+   */
+  onSeeking() {
+  }
+
+  /**
+   * while the media is running
+   */
+  onTimeUpdate() {
+  }
+
+  /**
+   * video ends
+   */
+  onVideoEnd() {
+  }
+
+  onVideoError() {
+  }
+
+  /**
+   * when user clicks to pause the media content
+   */
+  onVideoStop() {
+  }
+
+  /**
+   * any volume change
+   */
+  onVolumeChange() {
+  }
+}

--- a/public/stylesheets/livetv-module.scss
+++ b/public/stylesheets/livetv-module.scss
@@ -1,0 +1,267 @@
+#livetv-module {
+  margin-top: 10px;
+  overflow: hidden;
+
+  .livetv-title {
+    margin-bottom: 5px;
+    margin-left: 10px;
+    position: relative;
+    top: 15px;
+
+    .fa-circle {
+      background: -webkit-gradient(linear, left top, left bottom, from(#ff4040), to(#cc0000));
+        -webkit-background-clip: text;
+        -webkit-text-fill-color: transparent;
+      margin-right: 5px;
+    }
+  }
+
+  .wrap {
+    margin: 0 auto;
+    position: relative;
+  }
+
+  @media screen and (min-width: 1450px) {
+    .wrap {
+      left: -48vw;
+      width: 190vw;
+    }
+
+    .slider-container {
+      .play-tv-button {
+        font-size: 210px;
+        left: 43%;
+        position: absolute;
+        top: 38%;
+      }
+    }
+  }
+
+
+  @media screen and (max-width: 1449px) {
+    .wrap {
+      left: -45vw;
+      width: 185vw;
+    }
+
+    .slider-container {
+      .play-tv-button {
+        font-size: 200px;
+        left: 43%;
+        position: absolute;
+        top: 38%;
+      }
+    }
+  }
+
+  @media screen and (max-width: 1230px) {
+    .slider-container {
+      .play-tv-button {
+        font-size: 180px;
+        left: 43%;
+        position: absolute;
+        top: 38%;
+      }
+    }
+  }
+
+  @media screen and (max-width: 999px) {
+    .wrap {
+      left: -45vw;
+      width: 180vw;
+    }
+
+    .slider-container {
+      .play-tv-button {
+        font-size: 130px;
+        left: 42%;
+        position: absolute;
+        top: 35%;
+      }
+    }
+  }
+
+  @media screen and (max-width: 745px) {
+    .slider-container {
+      .play-tv-button {
+        font-size: 110px;
+        left: 43%;
+        position: absolute;
+        top: 35%;
+      }
+    }
+  }
+
+  @media screen and (max-width: 695px) {
+    .wrap {
+      left: -44vw;
+      width: 180vw;
+    }
+
+    .slider-container {
+      .play-tv-button {
+        font-size: 90px;
+        left: 42%;
+        position: absolute;
+        top: 38%;
+      }
+    }
+  }
+
+  @media screen and (max-width: 560px) {
+    .slider-container {
+      .play-tv-button {
+        font-size: 80px;
+        left: 42%;
+        position: absolute;
+        top: 38%;
+      }
+    }
+  }
+
+  @media screen and (max-width: 480px) {
+    .wrap {
+      left: -43vw;
+      width: 175vw;
+    }
+
+    .slider-container {
+      .play-tv-button {
+        font-size: 70px;
+        left: 42%;
+        position: absolute;
+        top: 35%;
+      }
+    }
+  }
+
+  @media screen and (max-width: 380px) {
+    .slider-container {
+      .play-tv-button {
+        font-size: 50px;
+        left: 42%;
+        position: absolute;
+        top: 35%;
+      }
+    }
+  }
+
+  .glide__slide {
+    margin: 0;
+    padding: 1px 0 0 0;
+    text-align: center;
+  }
+
+  .slider-container {
+    position: relative;
+
+    img {
+      &.section-image {
+        border-radius: 10px;
+        box-shadow: rgba(0, 0, 0, 0.05) 0px 6px 24px 0px, rgba(0, 0, 0, 0.08) 0px 0px 0px 1px;
+        width: 100%;
+      }
+    }
+
+    .section-empty-image {
+      background-color: #000;
+      border-radius: 10px;
+    }
+
+    .play-tv-button {
+      background-color: #fff;
+      border: solid 3px #cef46d;
+      border-radius: 50%;
+      color: #00c22b;
+      cursor: pointer;
+      position: absolute;
+    }
+
+    .play-tv-button:active {
+      background-color: #ff009d;
+      border: solid 3px #00c22b;
+      color: #cef46d;
+    }
+
+    .section-title {
+      bottom: 0;
+      color: #fff;
+      font-size: 11pt;
+      font-weight: 900;
+      left: 0;
+      margin: 0 0 15pt 10pt;
+      padding: 0;
+      position: absolute;
+      text-shadow: 2px 2px black;
+    }
+
+    .live-sign {
+      background-color: #00c22b;
+      border-radius: 30px;
+      color: #fff;
+      font-size: 10pt;
+      margin: 10px 15px 0 0;
+      padding: 7px 12px;
+      position: absolute;
+      right: 0;
+      top: 0;
+
+      span {
+        margin-right: 12px;
+      }
+
+      .fa-circle {
+        color: #fff;
+      }
+    }
+  }
+
+  .tv-buttons-container {
+    display: flex;
+    grid-template-columns: 1fr 1fr 1fr 1fr 1fr 1fr;
+    justify-content: space-around;
+  }
+
+  .tv-button {
+    border: 1px solid #fefefe;
+    border-radius: 30px;
+    cursor: pointer;
+    display: block;
+    height: 30px;
+    margin: 0;
+    padding: 0; 
+    position: relative;
+    width: 100px;
+
+    img {
+      height: 38px;
+      margin: -5px 0 0 0;
+      width: 38px;
+    }
+
+    &.disabled {
+      background-color: #f8f8f8;
+      img {
+        opacity: 0.2;
+      }
+    }
+
+    &:active {
+      background-color: #f6ccef;
+    }
+  }
+
+  .more-button {
+    background-color: #f6ccef;
+    font-size: 14px;
+    font-weight: 900;
+
+    &:active {
+      background-color: #d0519a;
+    }
+
+    a {
+      color: #000;
+    }
+  }
+}

--- a/public/stylesheets/shortcuts-module.scss
+++ b/public/stylesheets/shortcuts-module.scss
@@ -1,4 +1,6 @@
 #shortcuts-module {
+  margin-bottom: 0;
+  margin-top: 10px;
 
   .container-icon {
     align-items: center;

--- a/public/stylesheets/style.scss
+++ b/public/stylesheets/style.scss
@@ -1,18 +1,25 @@
 body {
   font-family: "Poppins", sans-serif;
   margin: 0;
+  max-width: 100vw;
   padding: 0;
 }
 
 .module {
-  margin: 10px;
+  margin: 40px 10px;
   padding: 0;
 }
+
 .title-section{
   font-size: 18px;
   font-weight: bold;
-  margin: 0px 10px;
+  margin: 0;
 }
+
 a{
   text-decoration: none;
+}
+
+.hidden {
+  display: none;
 }

--- a/views/index.hbs
+++ b/views/index.hbs
@@ -1,5 +1,5 @@
 {{#each modulesDataList}}
-  <section id="{{module_slug (modulePath)}}-module" class="module">
+  <section id="{{moduleSlug (modulePath)}}-module" class="module">
     {{> (modulePath) data=data }}
   </section>
 {{/each}}

--- a/views/layouts/main.hbs
+++ b/views/layouts/main.hbs
@@ -7,14 +7,24 @@
   <title></title>
   <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
   <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;500;600&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/normalize/5.0.0/normalize.min.css" />
+  <link rel='stylesheet' href='https://cdnjs.cloudflare.com/ajax/libs/Glide.js/3.0.2/css/glide.core.css' />
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.2.0/css/all.min.css" />
   <link rel="stylesheet" type="text/css" href="./stylesheets/style.css" />
   <link rel="stylesheet" type="text/css" href="./stylesheets/shortcuts-module.css" />
+  <link rel="stylesheet" type="text/css" href="./stylesheets/livetv-module.css" />
   <link rel="stylesheet" type="text/css" href="./stylesheets/videoondemand-module.css" />
 </head>
 
 <body>
   {{{body}}}
+
   <script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
+  <script src='https://cdnjs.cloudflare.com/ajax/libs/Glide.js/3.0.2/glide.js'></script>
+  <script src="https://platform-static.cdn.mdstrm.com/js/player_api.js"></script>
+  <script src="./javascripts/mediastream_video_player.js"></script>
+  <script src="./javascripts/livetv_mediastream_video_player.js"></script>
+  <script src="./javascripts/livetv_module.js"></script>
   <script src="./javascripts/index.js"></script>
 </body>
 

--- a/views/partials/example.hbs
+++ b/views/partials/example.hbs
@@ -1,6 +1,0 @@
-<h1>{{data.structure.title}}</h1>
-<center>
-  <img
-    src="https://image.winudf.com/v2/image1/Y29tLmNuaS5iYWNrcGlua19zY3JlZW5fMF8xNjAwNzc1ODQzXzAzMQ/screen-0.jpg?h=500&fakeurl=1&type=.jpg"
-    alt="BLACKPINK" width="65%"/>
-</center>

--- a/views/partials/livetv.hbs
+++ b/views/partials/livetv.hbs
@@ -1,0 +1,9 @@
+<p class="livetv-title title-section"><i class="fa fa-duotone fa-circle"></i>{{data.structure.title}}</p>
+{{> livetv/slider data=data}}
+{{> livetv/buttons data=data}}
+
+<script type="text/javascript">
+  document.addEventListener("DOMContentLoaded", function(event) { 
+    new LivetvModule();
+  });
+</script>

--- a/views/partials/livetv/buttons.hbs
+++ b/views/partials/livetv/buttons.hbs
@@ -1,0 +1,12 @@
+<div class="tv-buttons-container">
+  {{#each (limit data.content.canales 6)}}
+    {{#if (not (includes this.nombre 'baz'))}}
+      <button class="tv-button {{#if (not (hasDirectaTransmission this.transmisiones))}}disabled{{/if}}" type="button" data-mdstrm-identifier="{{firstTransmisionMediastreamId this.transmisiones}}">
+        <img src="{{miniLogo}}"/>
+      </button>
+    {{/if}}
+  {{/each}}
+  {{#if data.structure.more}}
+    <button class="tv-button more-button" type="button"><a href="app:videoondemand/dashboard">{{data.structure.more}}</a></button>
+  {{/if}}
+</div>

--- a/views/partials/livetv/slider.hbs
+++ b/views/partials/livetv/slider.hbs
@@ -1,0 +1,23 @@
+<div class="tv-slider wrap">
+  <div class="main-glide glide">
+    <div class="glide__track" data-glide-el="track">
+      <ul class="glide__slides">
+        {{setVar 'sliderIndex' 0}}
+        {{#each (limit data.content.canales 6)}}
+          {{#if (not (includes this.nombre 'baz'))}}
+            {{setVar 'directaFounded' false}}
+            {{#each this.transmisiones}}
+              {{#if (and (equals this.directa true) (equals @root.directaFounded false))}}
+                <li class="glide__slide">
+                  {{> livetv/slider/container transmission=this sliderIndex=@root.sliderIndex}}
+                </li>
+                {{setVar 'sliderIndex' (increment @root.sliderIndex)}}
+                {{setVar 'directaFounded' true}}
+              {{/if}}
+            {{/each}}
+          {{/if}}
+        {{/each}}
+      </ul>
+    </div>
+  </div>
+</div>

--- a/views/partials/livetv/slider/container.hbs
+++ b/views/partials/livetv/slider/container.hbs
@@ -1,0 +1,2 @@
+{{> livetv/slider/container/preview transmission=transmission sliderIndex=sliderIndex}}
+{{> livetv/slider/container/player transmission=transmission sliderIndex=sliderIndex}}

--- a/views/partials/livetv/slider/container/player.hbs
+++ b/views/partials/livetv/slider/container/player.hbs
@@ -1,0 +1,3 @@
+<div id="slider-container-player-{{transmission.videos.id}}" class="slider-container player hidden" data-slider-index="{{sliderIndex}}">
+  <div id="mdstrm-player-{{transmission.videos.id}}"></div>
+</div>

--- a/views/partials/livetv/slider/container/preview.hbs
+++ b/views/partials/livetv/slider/container/preview.hbs
@@ -1,0 +1,11 @@
+<div id="slider-container-preview-{{transmission.videos.id}}" class="slider-container preview" data-slider-index="{{sliderIndex}}">
+  {{#if transmission.urlImagen}}
+    <img class="section-image" alt="{{transmission.nombre}}" src="{{transmission.urlImagen}}" />
+  {{else}}
+    <div class="section-empty-image"></div>
+  {{/if}}
+
+  <i class="play-tv-button fa fa-play-circle fa-5x" aria-hidden="true" data-mdstrm-identifier="{{transmission.videos.id}}"></i>
+  <p class="section-title">{{incompleteString transmission.nombre 30}}</p>
+  <div class="live-sign"><span>En Vivo</span><i class="fa fa-duotone fa-circle fa-xs"></i></div>
+</div>

--- a/views/partials/shortcuts.hbs
+++ b/views/partials/shortcuts.hbs
@@ -1,4 +1,3 @@
-<h2>{{data.structure.title}}</h2>
 <div class="container-icon">
   {{#each data.content.shortcuts}}
     <a class="icon-m1" href="app:shortcuts/{{this.slug}}">


### PR DESCRIPTION
## Live tv module added
It is requested to add the live tv module to the web version to replace the current native android module. Below is the requested mockup along with its functional requirements.

<img width="1206" alt="image" src="https://user-images.githubusercontent.com/42450812/191022717-e0e44ee0-1aa7-4c03-9836-7fd5c1cc79da.png">

1. Player buttons. The native buttons of the mediastream player are preserved in the web version.
2. Carousel with 5 channels. The first 5 channels sent via the live json are always rendered, ignoring the Baz channel.
3. Auto play. Clicking the channel button automatically plays the transmission.
4. Channel selected by the user. Said channel is reproduced by moving the slider to position itself to the requested channel.
5. Channel disabled. Non-broadcasting channels are not part of the slider and the button for the non-broadcasting channel is grayed out.
6. The button to see more. The see more button is a deep link that is intended to launch the native activity of the live video dashboard.

Although not mentioned in the requirements, it was agreed that channels without transmission are not part of the slider and this is not an infinite carousel due to technological limitations.

### Technical details
Due to non-described behaviors or non-pre-established configurations that were programmed, it is necessary to give explicit details of the defined functionalities and variables.

The `LivetvModule` class encapsulates all of the module's behavior. The fullscreenEvent variable is used to identify if the user displays the player in full screen or on the contrary leaves full screen so that an exception can be made on the resize event of the window object on which code was added to reset the players. of video according to the current window size. On the other hand, the `lastDateTimeToFullscreen` variable is also related to this functionality described, however it was used to avoid the multiple execution of this event since it is the behavior that was identified when the user switches to full screen.

The `mediastreamVideoPlayers` variable is a json that will contain all the players with the identifiers of each feed to reuse the instances in case the user decides to replay a previously viewed stream.

An occasional problem, the cause of which could not be identified, is that the Glide library assigns a height of zero to the slider container, causing the slider to not be visible to users. For this reason, the `saveEmptyGlideSlidesException` function was defined, which ensures that the adjustment is always carried out, preventing this error from occurring again.

At a visual level, adjustments were made for different devices, although the objective is on smaller devices such as tablets or cell phones.


https://user-images.githubusercontent.com/42450812/191026271-fb3a234d-0718-41fc-af24-90b8b7cc6045.mp4


## Extra
- Added environment variable MAIN_WEBSITE_URL to consume a default url in case the url parameter is not part of the request.
- The title of the shortcuts module is removed
- Removed example module



